### PR TITLE
Add AppleScript selection run and dictionary loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Rich AppleScript language support for Visual Studio Code.
 
 - Syntax highlighting for AppleScript files (.scpt, .applescript, .scptd)
 - Custom icon support for AppleScript files
+- Run AppleScript files directly from the editor
+- Basic IntelliSense using application dictionaries (SDEF files)
+- Run only the selected AppleScript code
+- Load additional dictionaries for IntelliSense
 
 ## Requirements
 
@@ -22,9 +26,22 @@ You can install this extension through the VS Code Marketplace:
 
 To create a local VSIX package run `npx vsce package`.
 
+## Usage
+
+Open an AppleScript file and run the **Run AppleScript** command from the Command Palette (`Cmd+Shift+P`) or by right‑clicking in the editor. Use **Run Selected AppleScript** to execute just the highlighted code. Results are shown in a new terminal.
+
+Use **Load AppleScript Dictionary** to select additional SDEF files and enhance the completion suggestions.
+
 ## Known Issues
 
 Please report any issues on the [GitHub repository](https://github.com/KevinOBytes/vscode-applescript/issues).
+
+## Development
+
+1. Clone this repository and run `npm install`.
+2. Open the folder in VS Code and press `F5` to start the Extension Development Host.
+3. Run `npm test` to execute the unit tests.
+4. Build a `.vsix` package with `npx vsce package`.
 
 ## Release Notes
 
@@ -33,6 +50,13 @@ Please report any issues on the [GitHub repository](https://github.com/KevinOByt
 Initial release:
 - Basic syntax highlighting
 - File icon support
+- Run AppleScript command
+- Preliminary dictionary-based completions
+
+### 0.0.2
+
+- Run selected AppleScript code
+- Command to load additional dictionaries
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -12,13 +12,33 @@
   "keywords": [],
   "author": "",
   "license": "AGPL-3.0",
+  "main": "./out/extension.js",
   "dependencies": {},
   "engines": {
     "vscode": "^1.0.0"
   },
   "activationEvents": [
-    "onLanguage:applescript"
+    "onLanguage:applescript",
+    "onCommand:applescript.runScript",
+    "onCommand:applescript.runSelection",
+    "onCommand:applescript.loadDictionary"
   ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "applescript.runScript",
+        "title": "Run AppleScript"
+      },
+      {
+        "command": "applescript.runSelection",
+        "title": "Run Selected AppleScript"
+      },
+      {
+        "command": "applescript.loadDictionary",
+        "title": "Load AppleScript Dictionary"
+      }
+    ]
+  },
   "devDependencies": {
     "generator-code": "^1.11.4",
     "yo": "^5.0.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,6 @@ export function activate(context: vscode.ExtensionContext) {
         if (doc.isUntitled) {
             await doc.save();
         }
-        await doc.save();
         const command = `osascript "${doc.fileName}"`;
         const terminal = vscode.window.createTerminal('AppleScript');
         terminal.show(true);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,83 @@
+import * as vscode from 'vscode';
+import { exec } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+let dictionary: vscode.CompletionItem[] = [];
+
+function loadSdefDictionary(sdefPath: string) {
+    try {
+        const xml = fs.readFileSync(sdefPath, 'utf8');
+        const match = [...xml.matchAll(/<command name="([^"]+)"/g)];
+        dictionary = match.map(m => new vscode.CompletionItem(m[1], vscode.CompletionItemKind.Function));
+    } catch (err) {
+        console.error(`Failed to load dictionary from ${sdefPath}:`, err);
+    }
+}
+
+export function activate(context: vscode.ExtensionContext) {
+    const runScript = vscode.commands.registerCommand('applescript.runScript', async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            vscode.window.showInformationMessage('No active editor');
+            return;
+        }
+        const doc = editor.document;
+        if (doc.isUntitled) {
+            await doc.save();
+        }
+        await doc.save();
+        const command = `osascript "${doc.fileName}"`;
+        const terminal = vscode.window.createTerminal('AppleScript');
+        terminal.show(true);
+        terminal.sendText(command);
+    });
+    context.subscriptions.push(runScript);
+
+    const runSelection = vscode.commands.registerCommand('applescript.runSelection', async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            vscode.window.showInformationMessage('No active editor');
+            return;
+        }
+        const selection = editor.document.getText(editor.selection);
+        if (!selection.trim()) {
+            vscode.window.showInformationMessage('No selection to run');
+            return;
+        }
+        const tmpFile = path.join(os.tmpdir(), `vscode_applescript_${Date.now()}.applescript`);
+        fs.writeFileSync(tmpFile, selection);
+        const terminal = vscode.window.createTerminal('AppleScript');
+        terminal.show(true);
+        terminal.sendText(`osascript "${tmpFile}"`);
+    });
+    context.subscriptions.push(runSelection);
+
+    const loadDictionaryCmd = vscode.commands.registerCommand('applescript.loadDictionary', async () => {
+        const [uri] = await vscode.window.showOpenDialog({
+            canSelectMany: false,
+            filters: { 'SDEF files': ['sdef'] }
+        }) || [];
+        if (uri) {
+            loadSdefDictionary(uri.fsPath);
+            vscode.window.showInformationMessage(`Loaded dictionary from ${uri.fsPath}`);
+        }
+    });
+    context.subscriptions.push(loadDictionaryCmd);
+
+    const provider = vscode.languages.registerCompletionItemProvider('applescript', {
+        provideCompletionItems() {
+            return dictionary;
+        }
+    });
+    context.subscriptions.push(provider);
+
+    const defaultSdef = path.join(context.extensionPath, 'applescript-support', 'StandardAdditions.sdef');
+    if (fs.existsSync(defaultSdef)) {
+        loadSdefDictionary(defaultSdef);
+    }
+}
+
+export function deactivate() {}
+

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,9 +6,9 @@ import * as os from 'os';
 
 let dictionary: vscode.CompletionItem[] = [];
 
-function loadSdefDictionary(sdefPath: string) {
+async function loadSdefDictionary(sdefPath: string) {
     try {
-        const xml = fs.readFileSync(sdefPath, 'utf8');
+        const xml = await fs.promises.readFile(sdefPath, 'utf8');
         const match = [...xml.matchAll(/<command name="([^"]+)"/g)];
         dictionary = match.map(m => new vscode.CompletionItem(m[1], vscode.CompletionItemKind.Function));
     } catch (err) {


### PR DESCRIPTION
## Summary
- add commands to run selected script and load dictionary
- register new commands and extension entry point
- document new features and update release notes

## Testing
- `npm run compile`
- `npm test` *(fails: large output due to VS Code download)*

------
https://chatgpt.com/codex/tasks/task_e_686ad8878644832fa374c255ac1bf09a