### PR TITLE
Fix CI to run tests headlessly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm run build --if-present
-    - run: npm test --if-present 
+    - run: xvfb-run -a npm test --if-present 


### PR DESCRIPTION
## Summary
- run tests inside `xvfb-run` so `@vscode/test-electron` doesn't crash

## Testing
- `xvfb-run -a npm test`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_686adfba3588832fba6b113ccc578c45)